### PR TITLE
WIP: Add support to Hermes Engine

### DIFF
--- a/src/checkJSEngine.js
+++ b/src/checkJSEngine.js
@@ -1,0 +1,6 @@
+export const isHermesEngine = () => {
+  if (global === undefined) {
+    var global = window
+  }
+  return global.HermesInternal != null
+}

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { storeHandler } from './storeProxyHandler'
 import defaultConfig from './defaultConfig'
 import StoreContext from './StoreContext'
+import isHermesEngine from './checkJSEngine'
 
 /**
  * @param {ReactElement} WrappedComponent the component to connect with the store
@@ -62,7 +63,12 @@ const createStore = (
           return Object.assign({}, this.state.storage)
         }
       }
-      store = new Proxy(store, storeHandler)
+
+      // Proxy is not available at Hermes Engine used in React Native
+      if (!isHermesEngine()) {
+        store = new Proxy(store, storeHandler)
+      }
+
       this.setState({ store })
     }
 


### PR DESCRIPTION
## create checkJSEngine.js file

According to [hermes documentation](https://hermesengine.dev/) it is not a navigator.product, actually I think they use gecko navigator.

Also the react native recommends a [way to verify](https://facebook.github.io/react-native/docs/hermes/) if is using Hermes

## Also add verification on proxy call